### PR TITLE
Adds compatibility for Ghostscript >=9.50.0

### DIFF
--- a/includes/class-gopp-image-editor-gs.php
+++ b/includes/class-gopp-image-editor-gs.php
@@ -518,6 +518,12 @@ class GOPP_Image_Editor_GS extends WP_Image_Editor {
 		} else {
 			$ret .= ' -sstdout=/dev/null'; // Lessen noise.
 		}
+		
+		// Add compatibility for Ghostscript >=9.50.0
+		if( isset( wp_upload_dir()['basedir'] ) ) {
+			$ret .= ' -I' . self::escapeshellarg( wp_upload_dir()['basedir'] );
+		}
+		
 		$ret .= ' --'; // No more options.
 		$ret .= ' ' . self::escapeshellarg( $this->file );
 


### PR DESCRIPTION
This is so useful and still works with WP 5.6. However I had difficulties on a server with Ubuntu and Ghostscript 9.50.0. Just received the error `Failed to generate the PDF preview.`. Some debugging showed that the issue comes from Ghostscript and some reasearch clarified that since GhostScript 9.50 the SAFER mode has been turned ON by default, resulting in `/invalidfileaccess` errors.

This PR adds the WP upload path to the permitted reading list to solve `/invalidfileaccess` errors. However there would bee another solution to pass the sorce PDF path via `--permit-file-read=` but that requires some more changes in the plugin. So this is more a quick solution as the best solution.

See more: https://stackoverflow.com/a/61310729/1456459